### PR TITLE
fix: set order status

### DIFF
--- a/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_connection.py
+++ b/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_connection.py
@@ -103,6 +103,7 @@ def custom_create_sales_order(order, woocommerce_settings, customer_name, sys_la
 	set_items_in_sales_order(new_sales_order, woocommerce_settings, order, sys_lang)
 	new_sales_order.flags.ignore_mandatory = True
 	new_sales_order.insert()
+	new_sales_order.set_status()
 	new_sales_order.submit()
 
 	# manually commit, following convention in ERPNext


### PR DESCRIPTION
## Description

Set the order status when creating Sales Orders from WooCommerce orders

## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Tests

- [ ] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field  and Variable naming)
- [x] No Form changes */* My code follows the [Form Design Guidelines](https://github.com/frappe/erpnext/wiki/Form-Design-Guidelines)
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas */* No comments necessary
- [ ] I have made corresponding additions/changes to the documentation
- [x] All business logic and validations are on the server-side */* No business logic or validation changes
- [x] No patches are necessary */* Migration Patches have been added to the correct subdirectory of `/patches` and `patches.txt` have been updated


## User Experience:

>*This text can be deleted*
N/A
