### PR TITLE
Fix/woo order status

### DIFF
--- a/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_connection.py
+++ b/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_connection.py
@@ -103,7 +103,6 @@ def custom_create_sales_order(order, woocommerce_settings, customer_name, sys_la
 	set_items_in_sales_order(new_sales_order, woocommerce_settings, order, sys_lang)
 	new_sales_order.flags.ignore_mandatory = True
 	new_sales_order.insert()
-	new_sales_order.set_status()
 	new_sales_order.submit()
 
 	# manually commit, following convention in ERPNext

--- a/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_settings.py
+++ b/woocommerce_fusion/overrides/erpnext_integrations/woocommerce_settings.py
@@ -23,23 +23,27 @@ class CustomWoocommerceSettings(WoocommerceSettings):
 						read_only=1,
 						print_hide=1,
 					),
-					("Sales Order"): [
-						dict(
-							fieldname="woocommerce_status",
-							label="Woocommerce Status",
-							fieldtype="Select",
-							options="\nPending Payment\nOn hold\nFailed\nCancelled"
-							"\nProcessing\nRefunded\nShipped\nReady for Pickup"
-							"\nPicked up\nDelivered\nProcessing LP\nDraft\n",
-							allow_on_submit=1,
-						),
-						dict(fieldname="woocommerce_shipment_tracking_html", label="", fieldtype="HTML"),
-					],
+					("Sales Order"): dict(
+						fieldname="woocommerce_status",
+						label="Woocommerce Status",
+						fieldtype="Select",
+						options="\nPending Payment\nOn hold\nFailed\nCancelled"
+						"\nProcessing\nRefunded\nShipped\nReady for Pickup"
+						"\nPicked up\nDelivered\nProcessing LP\nDraft\n",
+						allow_on_submit=1,
+					),
 					("Item"): dict(
 						fieldname="woocommerce_servers",
 						label="",
 						fieldtype="Table",
 						options="Item WooCommerce Server",
+					),
+				}
+			)
+			create_custom_fields(
+				{
+					("Sales Order"): dict(
+						fieldname="woocommerce_shipment_tracking_html", label="", fieldtype="HTML"
 					),
 				}
 			)


### PR DESCRIPTION
## Description

- fix: custom field creation bug 
  - This issue caused the `woocommerce_status` field to never be created


## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Tests

- [ ] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field  and Variable naming)
- [x] No Form changes */* My code follows the [Form Design Guidelines](https://github.com/frappe/erpnext/wiki/Form-Design-Guidelines)
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas */* No comments necessary
- [ ] I have made corresponding additions/changes to the documentation
- [x] All business logic and validations are on the server-side */* No business logic or validation changes
- [x] No patches are necessary */* Migration Patches have been added to the correct subdirectory of `/patches` and `patches.txt` have been updated


## User Experience:

N/A
