### PR TITLE
fix: Add the endpoint for product variations

### DIFF
--- a/woocommerce_fusion/tasks/stock_update.py
+++ b/woocommerce_fusion/tasks/stock_update.py
@@ -109,7 +109,20 @@ def update_stock_levels_on_woocommerce_site(item_code):
 				}
 
 				try:
-					response = wc_api.put(endpoint=f"products/{woocommerce_id}", data=data_to_post)
+					parent_item_id = item.variant_of
+					if parent_item_id:
+						parent_item = frappe.get_doc("Item", parent_item_id)
+						# Get the parent item's woocommerce_id
+						for parent_wc_site in parent_item.woocommerce_servers:
+							if parent_wc_site.woocommerce_server == woocommerce_server:
+								parent_woocommerce_id = parent_wc_site.woocommerce_id
+								break
+						if not parent_woocommerce_id:
+							continue
+						endpoint = f"products/{parent_woocommerce_id}/variations/{woocommerce_id}"
+					else:
+						endpoint = f"products/{woocommerce_id}"
+					response = wc_api.put(endpoint=endpoint, data=data_to_post)
 				except Exception as err:
 					error_message = f"{frappe.get_traceback()}\n\nData in PUT request: \n{str(data_to_post)}"
 					frappe.log_error("WooCommerce Error", error_message)


### PR DESCRIPTION
## Description

There is an issue with the endpoint of variable product, according to [woocommerce api documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product-variation) the endpoint changes. This causes the problem of not being able to sync stock with this type of products.

It should fix #127 

## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)