### PR TITLE
fix: update the docs website url from the broken one

### DIFF
--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
@@ -148,7 +148,7 @@
   },
   {
    "description": "This company will be used to create Sales Orders.",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/sales-order.html",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/sales-order.html",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
@@ -218,7 +218,7 @@
   },
   {
    "default": "1",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/configure.html",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/configure.html",
    "fieldname": "enable_sync",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -247,7 +247,7 @@
   },
   {
    "default": "0",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/woocommerce-plugins.html",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/woocommerce-plugins.html",
    "fieldname": "wc_plugin_advanced_shipment_tracking",
    "fieldtype": "Check",
    "label": "Enable integration with 'Advanced Shipment Tracking' WooCommerce Plugin"
@@ -289,7 +289,7 @@
   },
   {
    "default": "0",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/item-prices.html",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/item-prices.html",
    "fieldname": "enable_price_list_sync",
    "fieldtype": "Check",
    "label": "Enable Price List Sync"
@@ -375,7 +375,7 @@
   },
   {
    "default": "0",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/item-stock-levels.html",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/item-stock-levels.html",
    "fieldname": "enable_stock_level_synchronisation",
    "fieldtype": "Check",
    "label": "Enable Stock Level Synchronisation"
@@ -423,7 +423,7 @@
    "label": "Item Fields"
   },
   {
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/items.html#custom-fields-mapping",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/items.html#custom-fields-mapping",
    "fieldname": "item_field_map",
    "fieldtype": "Table",
    "label": "Fields Mapping",
@@ -462,7 +462,7 @@
   },
   {
    "default": "0",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/sales-order.html#shipping-rule-synchronisation",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/sales-order.html#shipping-rule-synchronisation",
    "fieldname": "enable_shipping_methods_sync",
    "fieldtype": "Check",
    "label": "Enable Shipping Methods Sync"
@@ -482,7 +482,7 @@
   {
    "default": "0",
    "description": "When enabled the Order Status for both ERPNext and WooCommerce orders will be automatically updated if either changes",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/sales-order.html#automatic-order-status-synchronisation",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/sales-order.html#automatic-order-status-synchronisation",
    "fieldname": "enable_so_status_sync",
    "fieldtype": "Check",
    "label": "Keep the Status of ERPNext Sales Orders and WooCommerce Orders in sync"
@@ -550,7 +550,7 @@
    "options": "<div class=\"alert alert-warning\">\nMapping item fields is recommended for advanced users only. Make sure to monitor Error Logs after adding field mappings.\n</div>"
   },
   {
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/items.html#custom-fields-mapping",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/items.html#custom-fields-mapping",
    "fieldname": "order_line_item_field_map",
    "fieldtype": "Table",
    "label": "Fields Mapping",

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server_item_field/woocommerce_server_item_field.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server_item_field/woocommerce_server_item_field.json
@@ -24,7 +24,7 @@
   },
   {
    "description": "e.g. <code>$.short_description</code> or <code>$.meta_data[0].value</code> where <code>$</code> refers to WooCommerce Product",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/items.html#custom-fields-mapping",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/items.html#custom-fields-mapping",
    "fieldname": "woocommerce_field_name",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server_order_item_field/woocommerce_server_order_item_field.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server_order_item_field/woocommerce_server_order_item_field.json
@@ -24,7 +24,7 @@
   },
   {
    "description": "e.g. <code>$.short_description</code> or <code>$.meta_data[0].value</code> where <code>$</code> refers to WooCommerce Product",
-   "documentation_url": "https://woocommerce-fusion-docs.finfoot.tech/features/sales-order.html#fields-mapping",
+   "documentation_url": "https://woocommerce-fusion-docs.starktail.com/features/sales-order.html#fields-mapping",
    "fieldname": "woocommerce_field_name",
    "fieldtype": "Data",
    "in_list_view": 1,


### PR DESCRIPTION
## Description

This PR fixes broken documentation links by replacing the outdated docs website with a working and up-to-date documentation URL.
## Type of change

- ⚪ Bug fix (change which fixes an issue)

## Tests

- [ ] Unit Tests have been updated or added, as required  
- [ ] UI Tests have been updated or added, as required  

_No tests were required as this change only updates documentation URLs._

## Checklist:

- [x] My code follows Naming Guidelines (DocType, Field and Variable naming)
- [x] No Form changes
- [x] My code follows the Coding Standards of this project
- [x] My code follows the Code Security Guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No comments necessary
- [x] I have made corresponding additions/changes to the documentation
- [x] No business logic or validation changes
- [x] No patches are necessary

## User Experience:

This change improves developer and user experience by ensuring documentation links are valid and accessible. No UI changes were made.
