### PR TITLE
fix sync items last timestamp

### DIFF
--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -120,7 +120,7 @@ def sync_woocommerce_products_modified_since(date_time_from=None):
 		except Exception:
 			pass
 
-	frappe.db.set_single_value("WooCommerce Settings", "wc_last_sync_date_items", now())
+	frappe.db.set_single_value("WooCommerce Integration Settings", "wc_last_sync_date_items", now())
 
 
 @dataclass

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -89,10 +89,10 @@ def sync_woocommerce_orders_modified_since(date_time_from=None):
 	# Validate
 	if not date_time_from:
 		error_text = _(
-			"'Last Items Syncronisation Date' field on 'WooCommerce Integration Settings' is missing"
+			"'Last Sales Orders Syncronisation Date' field on 'WooCommerce Integration Settings' is missing"
 		)
 		frappe.log_error(
-			"WooCommerce Items Sync Task Error",
+			"WooCommerce Sales Orders Sync Task Error",
 			error_text,
 		)
 		raise ValueError(error_text)
@@ -106,7 +106,7 @@ def sync_woocommerce_orders_modified_since(date_time_from=None):
 		except Exception:
 			pass
 
-	frappe.db.set_single_value("WooCommerce Settings", "wc_last_sync_date_items", now())
+	frappe.db.set_single_value("WooCommerce Integration Settings", "wc_last_sync_date", now())
 
 
 class SynchroniseSalesOrder(SynchroniseWooCommerce):


### PR DESCRIPTION
## Description

An error occured in production:

```
WooCommerce Items Sync Task Error
'Last Items Syncronisation Date' field on 'WooCommerce Integration Settings' is missing
```


this PR tries to fix it.

## Type of change

- [x] Bug fix (change which fixes an issue)