### PR TITLE
Fix variants import

### DIFF
--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_product/woocommerce_product.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_product/woocommerce_product.py
@@ -124,6 +124,9 @@ class WooCommerceProduct(WooCommerceResource):
 		Perform some tasks to make sure that an product is in the correct format for the WC API
 		"""
 
+		if product.get("type") == "variation" or product.get("parent_id"):
+			product["status"] = "publish"
+
 		# Convert back to string
 		product["weight"] = str(product["weight"])
 		product["regular_price"] = str(product["regular_price"])


### PR DESCRIPTION
## Description

Variants import is broken currently, because they are marked as status = draft, which makes them invisible in woocommerce.

The solution is to mark them as status = publish and publish or not publish the product in woocommerce by toggling the parent product, not the variants.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Resolves https://github.com/Starktail/woocommerce_fusion/issues/128